### PR TITLE
Replace git clone role with ansible git command

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: "sqitch-migrations"
+  role_name: "sqitch_migrations"
   author: Ona Engineering
   description: Simple role to run database migrations using sqitch
   company: Ona Systems Inc

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -2,9 +2,6 @@
 - name: onaio.sqitch
   src: git+https://github.com/onaio/ansible-sqitch
   version: v1.0.0
-- name: adamyala.ansible-role-clone-repo
-  src: git+https://github.com/adamyala/ansible-role-clone-repo
-  version: 5de19d460af527a5c80d01326a629208008e7c3d
 - name: ANXS.postgresql
   src: git+https://github.com/ANXS/postgresql
   version: d8fc0d3316aa7ed099f23ce3a5546a74734aef8d

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,3 @@
 - name: onaio.sqitch
   src: git+https://github.com/onaio/ansible-sqitch
   version: v1.0.0
-- name: adamyala.ansible-role-clone-repo
-  src: git+https://github.com/adamyala/ansible-role-clone-repo
-  version: 5de19d460af527a5c80d01326a629208008e7c3d

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -5,3 +5,4 @@
     dest: "{{ repo.destination }}"
     version: "{{ repo.version }}"
     recursive: true
+  tags: git

--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -1,13 +1,7 @@
 ---
 - name: Clone {{ repo.url }}
-  include_role:
-    name: adamyala.ansible-role-clone-repo
-  vars:
-    ansible_become: false
-    ansible_user: "{{ sqitch_migrations_system_user }}"
-    gh_repo: "{{ repo.url }}"
-    gh_branch: "{{ repo.version }}"
-    dest_dir: "{{ repo.destination }}"
-    dest_dir_owner: "{{ sqitch_migrations_system_user }}"
-    dest_dir_group: "{{ sqitch_migrations_system_group }}"
-    dest_dir_perm: 0755
+  git:
+    repo: "{{ repo.url }}"
+    dest: "{{ repo.destination }}"
+    version: "{{ repo.version }}"
+    recursive: true

--- a/tasks/db/cron.yml
+++ b/tasks/db/cron.yml
@@ -7,6 +7,7 @@
     owner: "{{ sqitch_migrations_system_user }}"
     group: "{{ sqitch_migrations_system_group }}"
     path: "{{ sqitch_migrations_log_path }}/{{ job.key }}.log"
+    mode: 0644
 - name: Create cron jobs for {{ job.key }}
   cron:
     name: "{{ item.file }}"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -27,6 +27,7 @@
     owner: "{{ sqitch_migrations_system_user }}"
     group: "{{ sqitch_migrations_system_group }}"
     path: "{{ item }}"
+    mode: 0644
   when:
     - item is defined
     - item != None
@@ -46,7 +47,7 @@
 
 - name: Clone repositories
   include_tasks: clone.yml
-  with_items: '{{ sqitch_migrations_repositories }}'
+  with_items: "{{ sqitch_migrations_repositories }}"
   loop_control:
     loop_var: repo
   when:
@@ -54,7 +55,7 @@
 
 - name: Setup database
   include_tasks: db/setup.yml
-  loop: '{{ sqitch_migrations_sql_for_setup | dict2items }}'
+  loop: "{{ sqitch_migrations_sql_for_setup | dict2items }}"
   loop_control:
     loop_var: sql_item
   when:


### PR DESCRIPTION
Removes this [ansible clone role](https://github.com/adamyala/ansible-role-clone-repo) which seems to be un-maintained.
Replaces it with ansible git command

Closes #3 