### PR TITLE
Ensure that cron jobs are correctly set up

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -53,6 +53,25 @@
       register: cron_exists
       failed_when: cron_exists is changed
 
+    # the next three tasks will test that periodic queries are successfully run
+    # apparently sometimes we need to manually start cron in the docker service
+    - name: Start cron inside docker container
+      command: cron -L15
+      ignore_errors: true  # because sometimes it is already working
+    # check that our periodic logs run by verifying that logs are created
+    - name: Wait for SQL cron log to be populated
+      wait_for:
+        path: /var/log/sqitch_migrations/db_user.log
+        search_regex: refresh_mat_view  # this comes from one of the queries run in the test
+    # Finally we check that the query was applied correctly in the database
+    # Incidentally, this also confirms that the .pgpass file works okay
+    - name: Verify that periodic SQL query run correctly
+      command: psql -U regular -h localhost -c 'select 1/count(*) from test.materialized_view_tracking' productiondb
+      become: true
+      become_user: nomad
+      register: sql_cron
+      failed_when: sql_cron.rc != 0
+
     - name: Verify logrotate has been configured
       replace:
         path: /etc/logrotate.d/sqitch_migrations

--- a/tasks/db/cron.yml
+++ b/tasks/db/cron.yml
@@ -1,6 +1,13 @@
 ---
 - name: Set cron vars for {{ job.key }}
   include_tasks: cron_vars.yml
+- name: Ensure log directory exists
+  file:
+    state: directory
+    owner: "{{ sqitch_migrations_system_user }}"
+    group: "{{ sqitch_migrations_system_group }}"
+    path: "{{ sqitch_migrations_log_path }}"
+    mode: "0744"
 - name: Ensure log file exists
   file:
     state: touch

--- a/tasks/db/cron.yml
+++ b/tasks/db/cron.yml
@@ -7,7 +7,7 @@
     owner: "{{ sqitch_migrations_system_user }}"
     group: "{{ sqitch_migrations_system_group }}"
     path: "{{ sqitch_migrations_log_path }}"
-    mode: "0744"
+    mode: "0755"
 - name: Ensure log file exists
   file:
     state: touch


### PR DESCRIPTION
This [PR](https://github.com/onaio/ansible-sqitch-migrations/pull/4) introduced [a change](https://github.com/onaio/ansible-sqitch-migrations/pull/4/files#diff-e9ddc4866465626b1b1cc66995c99adc628630452651722bbe333addd41166aeR10) where the permissions of the cron jobs log file was expicitly set to `0644`.  Unfortunately without also explicitly setting the permissions for the logs directly, those were also set to `0644`.  To fix this, the PR does the following:

- [x] Ensure that the logs directory gets a permission of `0755`
- [x] Add back the tests that checked for cron jobs actually running